### PR TITLE
Wasm support and some cleanup.

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,13 +15,22 @@ webgl_example.go:
 package main
 
 import (
-	"github.com/gopherjs/gopherjs/js"
+	"fmt"
+
+	"github.com/gopherjs/gopherwasm/js"
 	"github.com/gopherjs/webgl"
 )
 
 func main() {
-	document := js.Global.Get("document")
+	document := js.Global().Get("document")
 	canvas := document.Call("createElement", "canvas")
+	if canvas == js.Null() {
+		fmt.Println("CANVAS IS NULL")
+	}
+
+	canvas.Set("width", 800)
+	canvas.Set("height", 600)
+	canvas.Get("style").Set("outline", "none")
 	document.Get("body").Call("appendChild", canvas)
 
 	attrs := webgl.DefaultAttributes()
@@ -29,18 +38,40 @@ func main() {
 
 	gl, err := webgl.NewContext(canvas, attrs)
 	if err != nil {
-		js.Global.Call("alert", "Error: "+err.Error())
+		js.Global().Call("alert", "Error: "+err.Error())
 	}
 
-	gl.ClearColor(0.8, 0.3, 0.01, 1)
-	gl.Clear(gl.COLOR_BUFFER_BIT)
+	gl.Call("clearColor", 0.8, 0.3, 0.01, 1)
+	gl.Call("clear", gl.COLOR_BUFFER_BIT)
 }
 ```
 
-webgl_example.html:
+js_example.html:
 
 ```html
 <html><body><script src="webgl_example.js"></script></body></html>
 ```
 
 To produce `webgl_example.js` file, run `gopherjs build webgl_example.go`.
+
+wasm_example:
+```html
+<html>
+	<head>
+		<meta charset="utf-8">
+		<script src="wasm_exec.js"></script>
+		<script>
+			const go = new Go();
+			WebAssembly.instantiateStreaming(fetch("main.wasm"), go.importObject).then((result) => {
+				go.run(result.instance);
+			});
+		</script>
+	</head>
+	<body></body>
+</html>
+```
+
+1. `GOOS=js GOARCH=wasm go build -o main.wasm`
+2. `cp "$(go env GOROOT)/misc/wasm/wasm_exec.js"`
+3. Serve the files. E.g. with `goexec 'http.ListenAndServe(":8080", http.FileServer(http.Dir(".")))'`
+

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ func main() {
 	canvas := document.Call("createElement", "canvas")
 	if canvas == js.Null() {
 		fmt.Println("CANVAS IS NULL")
+		return
 	}
 
 	canvas.Set("width", 800)

--- a/webgl.go
+++ b/webgl.go
@@ -46,306 +46,308 @@ func DefaultAttributes() *ContextAttributes {
 type Context struct {
 	js.Value
 
-	ARRAY_BUFFER                                 int `js:"ARRAY_BUFFER"`
-	ARRAY_BUFFER_BINDING                         int `js:"ARRAY_BUFFER_BINDING"`
-	ATTACHED_SHADERS                             int `js:"ATTACHED_SHADERS"`
-	BACK                                         int `js:"BACK"`
-	BLEND                                        int `js:"BLEND"`
-	BLEND_COLOR                                  int `js:"BLEND_COLOR"`
-	BLEND_DST_ALPHA                              int `js:"BLEND_DST_ALPHA"`
-	BLEND_DST_RGB                                int `js:"BLEND_DST_RGB"`
-	BLEND_EQUATION                               int `js:"BLEND_EQUATION"`
-	BLEND_EQUATION_ALPHA                         int `js:"BLEND_EQUATION_ALPHA"`
-	BLEND_EQUATION_RGB                           int `js:"BLEND_EQUATION_RGB"`
-	BLEND_SRC_ALPHA                              int `js:"BLEND_SRC_ALPHA"`
-	BLEND_SRC_RGB                                int `js:"BLEND_SRC_RGB"`
-	BLUE_BITS                                    int `js:"BLUE_BITS"`
-	BOOL                                         int `js:"BOOL"`
-	BOOL_VEC2                                    int `js:"BOOL_VEC2"`
-	BOOL_VEC3                                    int `js:"BOOL_VEC3"`
-	BOOL_VEC4                                    int `js:"BOOL_VEC4"`
-	BROWSER_DEFAULT_WEBGL                        int `js:"BROWSER_DEFAULT_WEBGL"`
-	BUFFER_SIZE                                  int `js:"BUFFER_SIZE"`
-	BUFFER_USAGE                                 int `js:"BUFFER_USAGE"`
-	BYTE                                         int `js:"BYTE"`
-	CCW                                          int `js:"CCW"`
-	CLAMP_TO_EDGE                                int `js:"CLAMP_TO_EDGE"`
-	COLOR_ATTACHMENT0                            int `js:"COLOR_ATTACHMENT0"`
-	COLOR_BUFFER_BIT                             int `js:"COLOR_BUFFER_BIT"`
-	COLOR_CLEAR_VALUE                            int `js:"COLOR_CLEAR_VALUE"`
-	COLOR_WRITEMASK                              int `js:"COLOR_WRITEMASK"`
-	COMPILE_STATUS                               int `js:"COMPILE_STATUS"`
-	COMPRESSED_TEXTURE_FORMATS                   int `js:"COMPRESSED_TEXTURE_FORMATS"`
-	CONSTANT_ALPHA                               int `js:"CONSTANT_ALPHA"`
-	CONSTANT_COLOR                               int `js:"CONSTANT_COLOR"`
-	CONTEXT_LOST_WEBGL                           int `js:"CONTEXT_LOST_WEBGL"`
-	CULL_FACE                                    int `js:"CULL_FACE"`
-	CULL_FACE_MODE                               int `js:"CULL_FACE_MODE"`
-	CURRENT_PROGRAM                              int `js:"CURRENT_PROGRAM"`
-	CURRENT_VERTEX_ATTRIB                        int `js:"CURRENT_VERTEX_ATTRIB"`
-	CW                                           int `js:"CW"`
-	DECR                                         int `js:"DECR"`
-	DECR_WRAP                                    int `js:"DECR_WRAP"`
-	DELETE_STATUS                                int `js:"DELETE_STATUS"`
-	DEPTH_ATTACHMENT                             int `js:"DEPTH_ATTACHMENT"`
-	DEPTH_BITS                                   int `js:"DEPTH_BITS"`
-	DEPTH_BUFFER_BIT                             int `js:"DEPTH_BUFFER_BIT"`
-	DEPTH_CLEAR_VALUE                            int `js:"DEPTH_CLEAR_VALUE"`
-	DEPTH_COMPONENT                              int `js:"DEPTH_COMPONENT"`
-	DEPTH_COMPONENT16                            int `js:"DEPTH_COMPONENT16"`
-	DEPTH_FUNC                                   int `js:"DEPTH_FUNC"`
-	DEPTH_RANGE                                  int `js:"DEPTH_RANGE"`
-	DEPTH_STENCIL                                int `js:"DEPTH_STENCIL"`
-	DEPTH_STENCIL_ATTACHMENT                     int `js:"DEPTH_STENCIL_ATTACHMENT"`
-	DEPTH_TEST                                   int `js:"DEPTH_TEST"`
-	DEPTH_WRITEMASK                              int `js:"DEPTH_WRITEMASK"`
-	DITHER                                       int `js:"DITHER"`
-	DONT_CARE                                    int `js:"DONT_CARE"`
-	DST_ALPHA                                    int `js:"DST_ALPHA"`
-	DST_COLOR                                    int `js:"DST_COLOR"`
-	DYNAMIC_DRAW                                 int `js:"DYNAMIC_DRAW"`
-	ELEMENT_ARRAY_BUFFER                         int `js:"ELEMENT_ARRAY_BUFFER"`
-	ELEMENT_ARRAY_BUFFER_BINDING                 int `js:"ELEMENT_ARRAY_BUFFER_BINDING"`
-	EQUAL                                        int `js:"EQUAL"`
-	FASTEST                                      int `js:"FASTEST"`
-	FLOAT                                        int `js:"FLOAT"`
-	FLOAT_MAT2                                   int `js:"FLOAT_MAT2"`
-	FLOAT_MAT3                                   int `js:"FLOAT_MAT3"`
-	FLOAT_MAT4                                   int `js:"FLOAT_MAT4"`
-	FLOAT_VEC2                                   int `js:"FLOAT_VEC2"`
-	FLOAT_VEC3                                   int `js:"FLOAT_VEC3"`
-	FLOAT_VEC4                                   int `js:"FLOAT_VEC4"`
-	FRAGMENT_SHADER                              int `js:"FRAGMENT_SHADER"`
-	FRAMEBUFFER                                  int `js:"FRAMEBUFFER"`
-	FRAMEBUFFER_ATTACHMENT_OBJECT_NAME           int `js:"FRAMEBUFFER_ATTACHMENT_OBJECT_NAME"`
-	FRAMEBUFFER_ATTACHMENT_OBJECT_TYPE           int `js:"FRAMEBUFFER_ATTACHMENT_OBJECT_TYPE"`
-	FRAMEBUFFER_ATTACHMENT_TEXTURE_CUBE_MAP_FACE int `js:"FRAMEBUFFER_ATTACHMENT_TEXTURE_CUBE_MAP_FACE"`
-	FRAMEBUFFER_ATTACHMENT_TEXTURE_LEVEL         int `js:"FRAMEBUFFER_ATTACHMENT_TEXTURE_LEVEL"`
-	FRAMEBUFFER_BINDING                          int `js:"FRAMEBUFFER_BINDING"`
-	FRAMEBUFFER_COMPLETE                         int `js:"FRAMEBUFFER_COMPLETE"`
-	FRAMEBUFFER_INCOMPLETE_ATTACHMENT            int `js:"FRAMEBUFFER_INCOMPLETE_ATTACHMENT"`
-	FRAMEBUFFER_INCOMPLETE_DIMENSIONS            int `js:"FRAMEBUFFER_INCOMPLETE_DIMENSIONS"`
-	FRAMEBUFFER_INCOMPLETE_MISSING_ATTACHMENT    int `js:"FRAMEBUFFER_INCOMPLETE_MISSING_ATTACHMENT"`
-	FRAMEBUFFER_UNSUPPORTED                      int `js:"FRAMEBUFFER_UNSUPPORTED"`
-	FRONT                                        int `js:"FRONT"`
-	FRONT_AND_BACK                               int `js:"FRONT_AND_BACK"`
-	FRONT_FACE                                   int `js:"FRONT_FACE"`
-	FUNC_ADD                                     int `js:"FUNC_ADD"`
-	FUNC_REVERSE_SUBTRACT                        int `js:"FUNC_REVERSE_SUBTRACT"`
-	FUNC_SUBTRACT                                int `js:"FUNC_SUBTRACT"`
-	GENERATE_MIPMAP_HINT                         int `js:"GENERATE_MIPMAP_HINT"`
-	GEQUAL                                       int `js:"GEQUAL"`
-	GREATER                                      int `js:"GREATER"`
-	GREEN_BITS                                   int `js:"GREEN_BITS"`
-	HIGH_FLOAT                                   int `js:"HIGH_FLOAT"`
-	HIGH_INT                                     int `js:"HIGH_INT"`
-	INCR                                         int `js:"INCR"`
-	INCR_WRAP                                    int `js:"INCR_WRAP"`
-	INT                                          int `js:"INT"`
-	INT_VEC2                                     int `js:"INT_VEC2"`
-	INT_VEC3                                     int `js:"INT_VEC3"`
-	INT_VEC4                                     int `js:"INT_VEC4"`
-	INVALID_ENUM                                 int `js:"INVALID_ENUM"`
-	INVALID_FRAMEBUFFER_OPERATION                int `js:"INVALID_FRAMEBUFFER_OPERATION"`
-	INVALID_OPERATION                            int `js:"INVALID_OPERATION"`
-	INVALID_VALUE                                int `js:"INVALID_VALUE"`
-	INVERT                                       int `js:"INVERT"`
-	KEEP                                         int `js:"KEEP"`
-	LEQUAL                                       int `js:"LEQUAL"`
-	LESS                                         int `js:"LESS"`
-	LINEAR                                       int `js:"LINEAR"`
-	LINEAR_MIPMAP_LINEAR                         int `js:"LINEAR_MIPMAP_LINEAR"`
-	LINEAR_MIPMAP_NEAREST                        int `js:"LINEAR_MIPMAP_NEAREST"`
-	LINES                                        int `js:"LINES"`
-	LINE_LOOP                                    int `js:"LINE_LOOP"`
-	LINE_STRIP                                   int `js:"LINE_STRIP"`
-	LINE_WIDTH                                   int `js:"LINE_WIDTH"`
-	LINK_STATUS                                  int `js:"LINK_STATUS"`
-	LOW_FLOAT                                    int `js:"LOW_FLOAT"`
-	LOW_INT                                      int `js:"LOW_INT"`
-	LUMINANCE                                    int `js:"LUMINANCE"`
-	LUMINANCE_ALPHA                              int `js:"LUMINANCE_ALPHA"`
-	MAX_COMBINED_TEXTURE_IMAGE_UNITS             int `js:"MAX_COMBINED_TEXTURE_IMAGE_UNITS"`
-	MAX_CUBE_MAP_TEXTURE_SIZE                    int `js:"MAX_CUBE_MAP_TEXTURE_SIZE"`
-	MAX_FRAGMENT_UNIFORM_VECTORS                 int `js:"MAX_FRAGMENT_UNIFORM_VECTORS"`
-	MAX_RENDERBUFFER_SIZE                        int `js:"MAX_RENDERBUFFER_SIZE"`
-	MAX_TEXTURE_IMAGE_UNITS                      int `js:"MAX_TEXTURE_IMAGE_UNITS"`
-	MAX_TEXTURE_SIZE                             int `js:"MAX_TEXTURE_SIZE"`
-	MAX_VARYING_VECTORS                          int `js:"MAX_VARYING_VECTORS"`
-	MAX_VERTEX_ATTRIBS                           int `js:"MAX_VERTEX_ATTRIBS"`
-	MAX_VERTEX_TEXTURE_IMAGE_UNITS               int `js:"MAX_VERTEX_TEXTURE_IMAGE_UNITS"`
-	MAX_VERTEX_UNIFORM_VECTORS                   int `js:"MAX_VERTEX_UNIFORM_VECTORS"`
-	MAX_VIEWPORT_DIMS                            int `js:"MAX_VIEWPORT_DIMS"`
-	MEDIUM_FLOAT                                 int `js:"MEDIUM_FLOAT"`
-	MEDIUM_INT                                   int `js:"MEDIUM_INT"`
-	MIRRORED_REPEAT                              int `js:"MIRRORED_REPEAT"`
-	NEAREST                                      int `js:"NEAREST"`
-	NEAREST_MIPMAP_LINEAR                        int `js:"NEAREST_MIPMAP_LINEAR"`
-	NEAREST_MIPMAP_NEAREST                       int `js:"NEAREST_MIPMAP_NEAREST"`
-	NEVER                                        int `js:"NEVER"`
-	NICEST                                       int `js:"NICEST"`
-	NONE                                         int `js:"NONE"`
-	NOTEQUAL                                     int `js:"NOTEQUAL"`
-	NO_ERROR                                     int `js:"NO_ERROR"`
-	ONE                                          int `js:"ONE"`
-	ONE_MINUS_CONSTANT_ALPHA                     int `js:"ONE_MINUS_CONSTANT_ALPHA"`
-	ONE_MINUS_CONSTANT_COLOR                     int `js:"ONE_MINUS_CONSTANT_COLOR"`
-	ONE_MINUS_DST_ALPHA                          int `js:"ONE_MINUS_DST_ALPHA"`
-	ONE_MINUS_DST_COLOR                          int `js:"ONE_MINUS_DST_COLOR"`
-	ONE_MINUS_SRC_ALPHA                          int `js:"ONE_MINUS_SRC_ALPHA"`
-	ONE_MINUS_SRC_COLOR                          int `js:"ONE_MINUS_SRC_COLOR"`
-	OUT_OF_MEMORY                                int `js:"OUT_OF_MEMORY"`
-	PACK_ALIGNMENT                               int `js:"PACK_ALIGNMENT"`
-	POINTS                                       int `js:"POINTS"`
-	POLYGON_OFFSET_FACTOR                        int `js:"POLYGON_OFFSET_FACTOR"`
-	POLYGON_OFFSET_FILL                          int `js:"POLYGON_OFFSET_FILL"`
-	POLYGON_OFFSET_UNITS                         int `js:"POLYGON_OFFSET_UNITS"`
-	RED_BITS                                     int `js:"RED_BITS"`
-	RENDERBUFFER                                 int `js:"RENDERBUFFER"`
-	RENDERBUFFER_ALPHA_SIZE                      int `js:"RENDERBUFFER_ALPHA_SIZE"`
-	RENDERBUFFER_BINDING                         int `js:"RENDERBUFFER_BINDING"`
-	RENDERBUFFER_BLUE_SIZE                       int `js:"RENDERBUFFER_BLUE_SIZE"`
-	RENDERBUFFER_DEPTH_SIZE                      int `js:"RENDERBUFFER_DEPTH_SIZE"`
-	RENDERBUFFER_GREEN_SIZE                      int `js:"RENDERBUFFER_GREEN_SIZE"`
-	RENDERBUFFER_HEIGHT                          int `js:"RENDERBUFFER_HEIGHT"`
-	RENDERBUFFER_INTERNAL_FORMAT                 int `js:"RENDERBUFFER_INTERNAL_FORMAT"`
-	RENDERBUFFER_RED_SIZE                        int `js:"RENDERBUFFER_RED_SIZE"`
-	RENDERBUFFER_STENCIL_SIZE                    int `js:"RENDERBUFFER_STENCIL_SIZE"`
-	RENDERBUFFER_WIDTH                           int `js:"RENDERBUFFER_WIDTH"`
-	RENDERER                                     int `js:"RENDERER"`
-	REPEAT                                       int `js:"REPEAT"`
-	REPLACE                                      int `js:"REPLACE"`
-	RGB                                          int `js:"RGB"`
-	RGB5_A1                                      int `js:"RGB5_A1"`
-	RGB565                                       int `js:"RGB565"`
-	RGBA                                         int `js:"RGBA"`
-	RGBA4                                        int `js:"RGBA4"`
-	SAMPLER_2D                                   int `js:"SAMPLER_2D"`
-	SAMPLER_CUBE                                 int `js:"SAMPLER_CUBE"`
-	SAMPLES                                      int `js:"SAMPLES"`
-	SAMPLE_ALPHA_TO_COVERAGE                     int `js:"SAMPLE_ALPHA_TO_COVERAGE"`
-	SAMPLE_BUFFERS                               int `js:"SAMPLE_BUFFERS"`
-	SAMPLE_COVERAGE                              int `js:"SAMPLE_COVERAGE"`
-	SAMPLE_COVERAGE_INVERT                       int `js:"SAMPLE_COVERAGE_INVERT"`
-	SAMPLE_COVERAGE_VALUE                        int `js:"SAMPLE_COVERAGE_VALUE"`
-	SCISSOR_BOX                                  int `js:"SCISSOR_BOX"`
-	SCISSOR_TEST                                 int `js:"SCISSOR_TEST"`
-	SHADER_TYPE                                  int `js:"SHADER_TYPE"`
-	SHADING_LANGUAGE_VERSION                     int `js:"SHADING_LANGUAGE_VERSION"`
-	SHORT                                        int `js:"SHORT"`
-	SRC_ALPHA                                    int `js:"SRC_ALPHA"`
-	SRC_ALPHA_SATURATE                           int `js:"SRC_ALPHA_SATURATE"`
-	SRC_COLOR                                    int `js:"SRC_COLOR"`
-	STATIC_DRAW                                  int `js:"STATIC_DRAW"`
-	STENCIL_ATTACHMENT                           int `js:"STENCIL_ATTACHMENT"`
-	STENCIL_BACK_FAIL                            int `js:"STENCIL_BACK_FAIL"`
-	STENCIL_BACK_FUNC                            int `js:"STENCIL_BACK_FUNC"`
-	STENCIL_BACK_PASS_DEPTH_FAIL                 int `js:"STENCIL_BACK_PASS_DEPTH_FAIL"`
-	STENCIL_BACK_PASS_DEPTH_PASS                 int `js:"STENCIL_BACK_PASS_DEPTH_PASS"`
-	STENCIL_BACK_REF                             int `js:"STENCIL_BACK_REF"`
-	STENCIL_BACK_VALUE_MASK                      int `js:"STENCIL_BACK_VALUE_MASK"`
-	STENCIL_BACK_WRITEMASK                       int `js:"STENCIL_BACK_WRITEMASK"`
-	STENCIL_BITS                                 int `js:"STENCIL_BITS"`
-	STENCIL_BUFFER_BIT                           int `js:"STENCIL_BUFFER_BIT"`
-	STENCIL_CLEAR_VALUE                          int `js:"STENCIL_CLEAR_VALUE"`
-	STENCIL_FAIL                                 int `js:"STENCIL_FAIL"`
-	STENCIL_FUNC                                 int `js:"STENCIL_FUNC"`
-	STENCIL_INDEX8                               int `js:"STENCIL_INDEX8"`
-	STENCIL_PASS_DEPTH_FAIL                      int `js:"STENCIL_PASS_DEPTH_FAIL"`
-	STENCIL_PASS_DEPTH_PASS                      int `js:"STENCIL_PASS_DEPTH_PASS"`
-	STENCIL_REF                                  int `js:"STENCIL_REF"`
-	STENCIL_TEST                                 int `js:"STENCIL_TEST"`
-	STENCIL_VALUE_MASK                           int `js:"STENCIL_VALUE_MASK"`
-	STENCIL_WRITEMASK                            int `js:"STENCIL_WRITEMASK"`
-	STREAM_DRAW                                  int `js:"STREAM_DRAW"`
-	SUBPIXEL_BITS                                int `js:"SUBPIXEL_BITS"`
-	TEXTURE                                      int `js:"TEXTURE"`
-	TEXTURE0                                     int `js:"TEXTURE0"`
-	TEXTURE1                                     int `js:"TEXTURE1"`
-	TEXTURE2                                     int `js:"TEXTURE2"`
-	TEXTURE3                                     int `js:"TEXTURE3"`
-	TEXTURE4                                     int `js:"TEXTURE4"`
-	TEXTURE5                                     int `js:"TEXTURE5"`
-	TEXTURE6                                     int `js:"TEXTURE6"`
-	TEXTURE7                                     int `js:"TEXTURE7"`
-	TEXTURE8                                     int `js:"TEXTURE8"`
-	TEXTURE9                                     int `js:"TEXTURE9"`
-	TEXTURE10                                    int `js:"TEXTURE10"`
-	TEXTURE11                                    int `js:"TEXTURE11"`
-	TEXTURE12                                    int `js:"TEXTURE12"`
-	TEXTURE13                                    int `js:"TEXTURE13"`
-	TEXTURE14                                    int `js:"TEXTURE14"`
-	TEXTURE15                                    int `js:"TEXTURE15"`
-	TEXTURE16                                    int `js:"TEXTURE16"`
-	TEXTURE17                                    int `js:"TEXTURE17"`
-	TEXTURE18                                    int `js:"TEXTURE18"`
-	TEXTURE19                                    int `js:"TEXTURE19"`
-	TEXTURE20                                    int `js:"TEXTURE20"`
-	TEXTURE21                                    int `js:"TEXTURE21"`
-	TEXTURE22                                    int `js:"TEXTURE22"`
-	TEXTURE23                                    int `js:"TEXTURE23"`
-	TEXTURE24                                    int `js:"TEXTURE24"`
-	TEXTURE25                                    int `js:"TEXTURE25"`
-	TEXTURE26                                    int `js:"TEXTURE26"`
-	TEXTURE27                                    int `js:"TEXTURE27"`
-	TEXTURE28                                    int `js:"TEXTURE28"`
-	TEXTURE29                                    int `js:"TEXTURE29"`
-	TEXTURE30                                    int `js:"TEXTURE30"`
-	TEXTURE31                                    int `js:"TEXTURE31"`
-	TEXTURE_2D                                   int `js:"TEXTURE_2D"`
-	TEXTURE_BINDING_2D                           int `js:"TEXTURE_BINDING_2D"`
-	TEXTURE_BINDING_CUBE_MAP                     int `js:"TEXTURE_BINDING_CUBE_MAP"`
-	TEXTURE_CUBE_MAP                             int `js:"TEXTURE_CUBE_MAP"`
-	TEXTURE_CUBE_MAP_NEGATIVE_X                  int `js:"TEXTURE_CUBE_MAP_NEGATIVE_X"`
-	TEXTURE_CUBE_MAP_NEGATIVE_Y                  int `js:"TEXTURE_CUBE_MAP_NEGATIVE_Y"`
-	TEXTURE_CUBE_MAP_NEGATIVE_Z                  int `js:"TEXTURE_CUBE_MAP_NEGATIVE_Z"`
-	TEXTURE_CUBE_MAP_POSITIVE_X                  int `js:"TEXTURE_CUBE_MAP_POSITIVE_X"`
-	TEXTURE_CUBE_MAP_POSITIVE_Y                  int `js:"TEXTURE_CUBE_MAP_POSITIVE_Y"`
-	TEXTURE_CUBE_MAP_POSITIVE_Z                  int `js:"TEXTURE_CUBE_MAP_POSITIVE_Z"`
-	TEXTURE_MAG_FILTER                           int `js:"TEXTURE_MAG_FILTER"`
-	TEXTURE_MIN_FILTER                           int `js:"TEXTURE_MIN_FILTER"`
-	TEXTURE_WRAP_S                               int `js:"TEXTURE_WRAP_S"`
-	TEXTURE_WRAP_T                               int `js:"TEXTURE_WRAP_T"`
-	TRIANGLES                                    int `js:"TRIANGLES"`
-	TRIANGLE_FAN                                 int `js:"TRIANGLE_FAN"`
-	TRIANGLE_STRIP                               int `js:"TRIANGLE_STRIP"`
-	UNPACK_ALIGNMENT                             int `js:"UNPACK_ALIGNMENT"`
-	UNPACK_COLORSPACE_CONVERSION_WEBGL           int `js:"UNPACK_COLORSPACE_CONVERSION_WEBGL"`
-	UNPACK_FLIP_Y_WEBGL                          int `js:"UNPACK_FLIP_Y_WEBGL"`
-	UNPACK_PREMULTIPLY_ALPHA_WEBGL               int `js:"UNPACK_PREMULTIPLY_ALPHA_WEBGL"`
-	UNSIGNED_BYTE                                int `js:"UNSIGNED_BYTE"`
-	UNSIGNED_INT                                 int `js:"UNSIGNED_INT"`
-	UNSIGNED_SHORT                               int `js:"UNSIGNED_SHORT"`
-	UNSIGNED_SHORT_4_4_4_4                       int `js:"UNSIGNED_SHORT_4_4_4_4"`
-	UNSIGNED_SHORT_5_5_5_1                       int `js:"UNSIGNED_SHORT_5_5_5_1"`
-	UNSIGNED_SHORT_5_6_5                         int `js:"UNSIGNED_SHORT_5_6_5"`
-	VALIDATE_STATUS                              int `js:"VALIDATE_STATUS"`
-	VENDOR                                       int `js:"VENDOR"`
-	VERSION                                      int `js:"VERSION"`
-	VERTEX_ATTRIB_ARRAY_BUFFER_BINDING           int `js:"VERTEX_ATTRIB_ARRAY_BUFFER_BINDING"`
-	VERTEX_ATTRIB_ARRAY_ENABLED                  int `js:"VERTEX_ATTRIB_ARRAY_ENABLED"`
-	VERTEX_ATTRIB_ARRAY_NORMALIZED               int `js:"VERTEX_ATTRIB_ARRAY_NORMALIZED"`
-	VERTEX_ATTRIB_ARRAY_POINTER                  int `js:"VERTEX_ATTRIB_ARRAY_POINTER"`
-	VERTEX_ATTRIB_ARRAY_SIZE                     int `js:"VERTEX_ATTRIB_ARRAY_SIZE"`
-	VERTEX_ATTRIB_ARRAY_STRIDE                   int `js:"VERTEX_ATTRIB_ARRAY_STRIDE"`
-	VERTEX_ATTRIB_ARRAY_TYPE                     int `js:"VERTEX_ATTRIB_ARRAY_TYPE"`
-	VERTEX_SHADER                                int `js:"VERTEX_SHADER"`
-	VIEWPORT                                     int `js:"VIEWPORT"`
-	ZERO                                         int `js:"ZERO"`
+	ARRAY_BUFFER                                 int
+	ARRAY_BUFFER_BINDING                         int
+	ATTACHED_SHADERS                             int
+	BACK                                         int
+	BLEND                                        int
+	BLEND_COLOR                                  int
+	BLEND_DST_ALPHA                              int
+	BLEND_DST_RGB                                int
+	BLEND_EQUATION                               int
+	BLEND_EQUATION_ALPHA                         int
+	BLEND_EQUATION_RGB                           int
+	BLEND_SRC_ALPHA                              int
+	BLEND_SRC_RGB                                int
+	BLUE_BITS                                    int
+	BOOL                                         int
+	BOOL_VEC2                                    int
+	BOOL_VEC3                                    int
+	BOOL_VEC4                                    int
+	BROWSER_DEFAULT_WEBGL                        int
+	BUFFER_SIZE                                  int
+	BUFFER_USAGE                                 int
+	BYTE                                         int
+	CCW                                          int
+	CLAMP_TO_EDGE                                int
+	COLOR_ATTACHMENT0                            int
+	COLOR_BUFFER_BIT                             int
+	COLOR_CLEAR_VALUE                            int
+	COLOR_WRITEMASK                              int
+	COMPILE_STATUS                               int
+	COMPRESSED_TEXTURE_FORMATS                   int
+	CONSTANT_ALPHA                               int
+	CONSTANT_COLOR                               int
+	CONTEXT_LOST_WEBGL                           int
+	CULL_FACE                                    int
+	CULL_FACE_MODE                               int
+	CURRENT_PROGRAM                              int
+	CURRENT_VERTEX_ATTRIB                        int
+	CW                                           int
+	DECR                                         int
+	DECR_WRAP                                    int
+	DELETE_STATUS                                int
+	DEPTH_ATTACHMENT                             int
+	DEPTH_BITS                                   int
+	DEPTH_BUFFER_BIT                             int
+	DEPTH_CLEAR_VALUE                            int
+	DEPTH_COMPONENT                              int
+	DEPTH_COMPONENT16                            int
+	DEPTH_FUNC                                   int
+	DEPTH_RANGE                                  int
+	DEPTH_STENCIL                                int
+	DEPTH_STENCIL_ATTACHMENT                     int
+	DEPTH_TEST                                   int
+	DEPTH_WRITEMASK                              int
+	DITHER                                       int
+	DONT_CARE                                    int
+	DST_ALPHA                                    int
+	DST_COLOR                                    int
+	DYNAMIC_DRAW                                 int
+	ELEMENT_ARRAY_BUFFER                         int
+	ELEMENT_ARRAY_BUFFER_BINDING                 int
+	EQUAL                                        int
+	FASTEST                                      int
+	FLOAT                                        int
+	FLOAT_MAT2                                   int
+	FLOAT_MAT3                                   int
+	FLOAT_MAT4                                   int
+	FLOAT_VEC2                                   int
+	FLOAT_VEC3                                   int
+	FLOAT_VEC4                                   int
+	FRAGMENT_SHADER                              int
+	FRAMEBUFFER                                  int
+	FRAMEBUFFER_ATTACHMENT_OBJECT_NAME           int
+	FRAMEBUFFER_ATTACHMENT_OBJECT_TYPE           int
+	FRAMEBUFFER_ATTACHMENT_TEXTURE_CUBE_MAP_FACE int
+	FRAMEBUFFER_ATTACHMENT_TEXTURE_LEVEL         int
+	FRAMEBUFFER_BINDING                          int
+	FRAMEBUFFER_COMPLETE                         int
+	FRAMEBUFFER_INCOMPLETE_ATTACHMENT            int
+	FRAMEBUFFER_INCOMPLETE_DIMENSIONS            int
+	FRAMEBUFFER_INCOMPLETE_MISSING_ATTACHMENT    int
+	FRAMEBUFFER_UNSUPPORTED                      int
+	FRONT                                        int
+	FRONT_AND_BACK                               int
+	FRONT_FACE                                   int
+	FUNC_ADD                                     int
+	FUNC_REVERSE_SUBTRACT                        int
+	FUNC_SUBTRACT                                int
+	GENERATE_MIPMAP_HINT                         int
+	GEQUAL                                       int
+	GREATER                                      int
+	GREEN_BITS                                   int
+	HIGH_FLOAT                                   int
+	HIGH_INT                                     int
+	INCR                                         int
+	INCR_WRAP                                    int
+	INT                                          int
+	INT_VEC2                                     int
+	INT_VEC3                                     int
+	INT_VEC4                                     int
+	INVALID_ENUM                                 int
+	INVALID_FRAMEBUFFER_OPERATION                int
+	INVALID_OPERATION                            int
+	INVALID_VALUE                                int
+	INVERT                                       int
+	KEEP                                         int
+	LEQUAL                                       int
+	LESS                                         int
+	LINEAR                                       int
+	LINEAR_MIPMAP_LINEAR                         int
+	LINEAR_MIPMAP_NEAREST                        int
+	LINES                                        int
+	LINE_LOOP                                    int
+	LINE_STRIP                                   int
+	LINE_WIDTH                                   int
+	LINK_STATUS                                  int
+	LOW_FLOAT                                    int
+	LOW_INT                                      int
+	LUMINANCE                                    int
+	LUMINANCE_ALPHA                              int
+	MAX_COMBINED_TEXTURE_IMAGE_UNITS             int
+	MAX_CUBE_MAP_TEXTURE_SIZE                    int
+	MAX_FRAGMENT_UNIFORM_VECTORS                 int
+	MAX_RENDERBUFFER_SIZE                        int
+	MAX_TEXTURE_IMAGE_UNITS                      int
+	MAX_TEXTURE_SIZE                             int
+	MAX_VARYING_VECTORS                          int
+	MAX_VERTEX_ATTRIBS                           int
+	MAX_VERTEX_TEXTURE_IMAGE_UNITS               int
+	MAX_VERTEX_UNIFORM_VECTORS                   int
+	MAX_VIEWPORT_DIMS                            int
+	MEDIUM_FLOAT                                 int
+	MEDIUM_INT                                   int
+	MIRRORED_REPEAT                              int
+	NEAREST                                      int
+	NEAREST_MIPMAP_LINEAR                        int
+	NEAREST_MIPMAP_NEAREST                       int
+	NEVER                                        int
+	NICEST                                       int
+	NONE                                         int
+	NOTEQUAL                                     int
+	NO_ERROR                                     int
+	ONE                                          int
+	ONE_MINUS_CONSTANT_ALPHA                     int
+	ONE_MINUS_CONSTANT_COLOR                     int
+	ONE_MINUS_DST_ALPHA                          int
+	ONE_MINUS_DST_COLOR                          int
+	ONE_MINUS_SRC_ALPHA                          int
+	ONE_MINUS_SRC_COLOR                          int
+	OUT_OF_MEMORY                                int
+	PACK_ALIGNMENT                               int
+	POINTS                                       int
+	POLYGON_OFFSET_FACTOR                        int
+	POLYGON_OFFSET_FILL                          int
+	POLYGON_OFFSET_UNITS                         int
+	RED_BITS                                     int
+	RENDERBUFFER                                 int
+	RENDERBUFFER_ALPHA_SIZE                      int
+	RENDERBUFFER_BINDING                         int
+	RENDERBUFFER_BLUE_SIZE                       int
+	RENDERBUFFER_DEPTH_SIZE                      int
+	RENDERBUFFER_GREEN_SIZE                      int
+	RENDERBUFFER_HEIGHT                          int
+	RENDERBUFFER_INTERNAL_FORMAT                 int
+	RENDERBUFFER_RED_SIZE                        int
+	RENDERBUFFER_STENCIL_SIZE                    int
+	RENDERBUFFER_WIDTH                           int
+	RENDERER                                     int
+	REPEAT                                       int
+	REPLACE                                      int
+	RGB                                          int
+	RGB5_A1                                      int
+	RGB565                                       int
+	RGBA                                         int
+	RGBA4                                        int
+	SAMPLER_2D                                   int
+	SAMPLER_CUBE                                 int
+	SAMPLES                                      int
+	SAMPLE_ALPHA_TO_COVERAGE                     int
+	SAMPLE_BUFFERS                               int
+	SAMPLE_COVERAGE                              int
+	SAMPLE_COVERAGE_INVERT                       int
+	SAMPLE_COVERAGE_VALUE                        int
+	SCISSOR_BOX                                  int
+	SCISSOR_TEST                                 int
+	SHADER_TYPE                                  int
+	SHADING_LANGUAGE_VERSION                     int
+	SHORT                                        int
+	SRC_ALPHA                                    int
+	SRC_ALPHA_SATURATE                           int
+	SRC_COLOR                                    int
+	STATIC_DRAW                                  int
+	STENCIL_ATTACHMENT                           int
+	STENCIL_BACK_FAIL                            int
+	STENCIL_BACK_FUNC                            int
+	STENCIL_BACK_PASS_DEPTH_FAIL                 int
+	STENCIL_BACK_PASS_DEPTH_PASS                 int
+	STENCIL_BACK_REF                             int
+	STENCIL_BACK_VALUE_MASK                      int
+	STENCIL_BACK_WRITEMASK                       int
+	STENCIL_BITS                                 int
+	STENCIL_BUFFER_BIT                           int
+	STENCIL_CLEAR_VALUE                          int
+	STENCIL_FAIL                                 int
+	STENCIL_FUNC                                 int
+	STENCIL_INDEX8                               int
+	STENCIL_PASS_DEPTH_FAIL                      int
+	STENCIL_PASS_DEPTH_PASS                      int
+	STENCIL_REF                                  int
+	STENCIL_TEST                                 int
+	STENCIL_VALUE_MASK                           int
+	STENCIL_WRITEMASK                            int
+	STREAM_DRAW                                  int
+	SUBPIXEL_BITS                                int
+	TEXTURE                                      int
+	TEXTURE0                                     int
+	TEXTURE1                                     int
+	TEXTURE2                                     int
+	TEXTURE3                                     int
+	TEXTURE4                                     int
+	TEXTURE5                                     int
+	TEXTURE6                                     int
+	TEXTURE7                                     int
+	TEXTURE8                                     int
+	TEXTURE9                                     int
+	TEXTURE10                                    int
+	TEXTURE11                                    int
+	TEXTURE12                                    int
+	TEXTURE13                                    int
+	TEXTURE14                                    int
+	TEXTURE15                                    int
+	TEXTURE16                                    int
+	TEXTURE17                                    int
+	TEXTURE18                                    int
+	TEXTURE19                                    int
+	TEXTURE20                                    int
+	TEXTURE21                                    int
+	TEXTURE22                                    int
+	TEXTURE23                                    int
+	TEXTURE24                                    int
+	TEXTURE25                                    int
+	TEXTURE26                                    int
+	TEXTURE27                                    int
+	TEXTURE28                                    int
+	TEXTURE29                                    int
+	TEXTURE30                                    int
+	TEXTURE31                                    int
+	TEXTURE_2D                                   int
+	TEXTURE_BINDING_2D                           int
+	TEXTURE_BINDING_CUBE_MAP                     int
+	TEXTURE_CUBE_MAP                             int
+	TEXTURE_CUBE_MAP_NEGATIVE_X                  int
+	TEXTURE_CUBE_MAP_NEGATIVE_Y                  int
+	TEXTURE_CUBE_MAP_NEGATIVE_Z                  int
+	TEXTURE_CUBE_MAP_POSITIVE_X                  int
+	TEXTURE_CUBE_MAP_POSITIVE_Y                  int
+	TEXTURE_CUBE_MAP_POSITIVE_Z                  int
+	TEXTURE_MAG_FILTER                           int
+	TEXTURE_MIN_FILTER                           int
+	TEXTURE_WRAP_S                               int
+	TEXTURE_WRAP_T                               int
+	TRIANGLES                                    int
+	TRIANGLE_FAN                                 int
+	TRIANGLE_STRIP                               int
+	UNPACK_ALIGNMENT                             int
+	UNPACK_COLORSPACE_CONVERSION_WEBGL           int
+	UNPACK_FLIP_Y_WEBGL                          int
+	UNPACK_PREMULTIPLY_ALPHA_WEBGL               int
+	UNSIGNED_BYTE                                int
+	UNSIGNED_INT                                 int
+	UNSIGNED_SHORT                               int
+	UNSIGNED_SHORT_4_4_4_4                       int
+	UNSIGNED_SHORT_5_5_5_1                       int
+	UNSIGNED_SHORT_5_6_5                         int
+	VALIDATE_STATUS                              int
+	VENDOR                                       int
+	VERSION                                      int
+	VERTEX_ATTRIB_ARRAY_BUFFER_BINDING           int
+	VERTEX_ATTRIB_ARRAY_ENABLED                  int
+	VERTEX_ATTRIB_ARRAY_NORMALIZED               int
+	VERTEX_ATTRIB_ARRAY_POINTER                  int
+	VERTEX_ATTRIB_ARRAY_SIZE                     int
+	VERTEX_ATTRIB_ARRAY_STRIDE                   int
+	VERTEX_ATTRIB_ARRAY_TYPE                     int
+	VERTEX_SHADER                                int
+	VIEWPORT                                     int
+	ZERO                                         int
 }
 
 // initGlConstants initializes all GL constants from a webgl context.
 // This is necessary because wasm does not support struct tags.
 func (c *Context) initGlConstants() {
+
 	fields := reflect.TypeOf(*c)
 	num := fields.NumField()
+
 	// This functions is only called if creating a webgl context was successful.
 	// Thus we don't need to check here. Prototype is required for Safari.
+
 	ctx := js.Global().Get("WebGLRenderingContext").Get("prototype")
 
 	for i := 0; i < num; i++ {
 		field := fields.Field(i)
-
 		// Ignore the embedded js.Value. All other fields are gl constants.
 		if field.Name != "Value" {
 			// Retrieve value from gl context.
@@ -387,8 +389,8 @@ func NewContext(canvas js.Value, ca *ContextAttributes) (*Context, error) {
 		}
 	}
 	ctx := new(Context)
-	ctx.initGlConstants()
 	ctx.Value = gl
+	ctx.initGlConstants()
 	return ctx, nil
 }
 

--- a/webgl.go
+++ b/webgl.go
@@ -7,7 +7,7 @@ package webgl
 import (
 	"errors"
 
-	"github.com/gopherjs/gopherjs/js"
+	"github.com/gopherjs/gopherwasm/js"
 )
 
 type ContextAttributes struct {
@@ -43,7 +43,7 @@ func DefaultAttributes() *ContextAttributes {
 }
 
 type Context struct {
-	*js.Object
+	js.Value
 	ARRAY_BUFFER                                 int `js:"ARRAY_BUFFER"`
 	ARRAY_BUFFER_BINDING                         int `js:"ARRAY_BUFFER_BINDING"`
 	ATTACHED_SHADERS                             int `js:"ATTACHED_SHADERS"`
@@ -340,8 +340,8 @@ type Context struct {
 // NewContext takes an HTML5 canvas object and optional context attributes.
 // If an error is returned it means you won't have access to WebGL
 // functionality.
-func NewContext(canvas *js.Object, ca *ContextAttributes) (*Context, error) {
-	if js.Global.Get("WebGLRenderingContext") == js.Undefined {
+func NewContext(canvas js.Value, ca *ContextAttributes) (*Context, error) {
+	if js.Global().Get("WebGLRenderingContext").Get("prototype") == js.Null() {
 		return nil, errors.New("Your browser doesn't appear to support webgl.")
 	}
 
@@ -358,14 +358,14 @@ func NewContext(canvas *js.Object, ca *ContextAttributes) (*Context, error) {
 		"preserveDrawingBuffer": ca.PreserveDrawingBuffer,
 	}
 	gl := canvas.Call("getContext", "webgl", attrs)
-	if gl == nil {
+	if gl == js.Null() {
 		gl = canvas.Call("getContext", "experimental-webgl", attrs)
-		if gl == nil {
+		if gl == js.Null() {
 			return nil, errors.New("Creating a webgl context has failed.")
 		}
 	}
 	ctx := new(Context)
-	ctx.Object = gl
+	ctx.Value = gl
 	return ctx, nil
 }
 
@@ -390,32 +390,32 @@ func (c *Context) ActiveTexture(texture int) {
 }
 
 // Attaches a WebGLShader object to a WebGLProgram object.
-func (c *Context) AttachShader(program *js.Object, shader *js.Object) {
+func (c *Context) AttachShader(program js.Value, shader js.Value) {
 	c.Call("attachShader", program, shader)
 }
 
 // Binds a generic vertex index to a user-defined attribute variable.
-func (c *Context) BindAttribLocation(program *js.Object, index int, name string) {
+func (c *Context) BindAttribLocation(program js.Value, index int, name string) {
 	c.Call("bindAttribLocation", program, index, name)
 }
 
 // Associates a buffer with a buffer target.
-func (c *Context) BindBuffer(target int, buffer *js.Object) {
+func (c *Context) BindBuffer(target int, buffer js.Value) {
 	c.Call("bindBuffer", target, buffer)
 }
 
 // Associates a WebGLFramebuffer object with the FRAMEBUFFER bind target.
-func (c *Context) BindFramebuffer(target int, framebuffer *js.Object) {
+func (c *Context) BindFramebuffer(target int, framebuffer js.Value) {
 	c.Call("bindFramebuffer", target, framebuffer)
 }
 
 // Binds a WebGLRenderbuffer object to be used for rendering.
-func (c *Context) BindRenderbuffer(target int, renderbuffer *js.Object) {
+func (c *Context) BindRenderbuffer(target int, renderbuffer js.Value) {
 	c.Call("bindRenderbuffer", target, renderbuffer)
 }
 
 // Binds a named texture object to a target.
-func (c *Context) BindTexture(target int, texture *js.Object) {
+func (c *Context) BindTexture(target int, texture js.Value) {
 	c.Call("bindTexture", target, texture)
 }
 
@@ -489,7 +489,7 @@ func (c *Context) ColorMask(r, g, b, a bool) {
 }
 
 // Compiles the GLSL shader source into binary data used by the WebGLProgram object.
-func (c *Context) CompileShader(shader *js.Object) {
+func (c *Context) CompileShader(shader js.Value) {
 	c.Call("compileShader", shader)
 }
 
@@ -504,33 +504,33 @@ func (c *Context) CopyTexSubImage2D(target, level, xoffset, yoffset, x, y, w, h 
 }
 
 // Creates and initializes a WebGLBuffer.
-func (c *Context) CreateBuffer() *js.Object {
+func (c *Context) CreateBuffer() js.Value {
 	return c.Call("createBuffer")
 }
 
 // Returns a WebGLFramebuffer object.
-func (c *Context) CreateFramebuffer() *js.Object {
+func (c *Context) CreateFramebuffer() js.Value {
 	return c.Call("createFramebuffer")
 }
 
 // Creates an empty WebGLProgram object to which vector and fragment
 // WebGLShader objects can be bound.
-func (c *Context) CreateProgram() *js.Object {
+func (c *Context) CreateProgram() js.Value {
 	return c.Call("createProgram")
 }
 
 // Creates and returns a WebGLRenderbuffer object.
-func (c *Context) CreateRenderbuffer() *js.Object {
+func (c *Context) CreateRenderbuffer() js.Value {
 	return c.Call("createRenderbuffer")
 }
 
 // Returns an empty vertex or fragment shader object based on the type specified.
-func (c *Context) CreateShader(typ int) *js.Object {
+func (c *Context) CreateShader(typ int) js.Value {
 	return c.Call("createShader", typ)
 }
 
 // Used to generate a WebGLTexture object to which images can be bound.
-func (c *Context) CreateTexture() *js.Object {
+func (c *Context) CreateTexture() js.Value {
 	return c.Call("createTexture")
 }
 
@@ -540,14 +540,14 @@ func (c *Context) CullFace(mode int) {
 }
 
 // Delete a specific buffer.
-func (c *Context) DeleteBuffer(buffer *js.Object) {
+func (c *Context) DeleteBuffer(buffer js.Value) {
 	c.Call("deleteBuffer", buffer)
 }
 
 // Deletes a specific WebGLFramebuffer object. If you delete the
 // currently bound framebuffer, the default framebuffer will be bound.
 // Deleting a framebuffer detaches all of its attachments.
-func (c *Context) DeleteFramebuffer(framebuffer *js.Object) {
+func (c *Context) DeleteFramebuffer(framebuffer js.Value) {
 	c.Call("deleteFramebuffer", framebuffer)
 }
 
@@ -555,24 +555,24 @@ func (c *Context) DeleteFramebuffer(framebuffer *js.Object) {
 // It will be deleted when it is no longer being used.
 // Any shader objects associated with the program will be detached.
 // They will be deleted if they were already flagged for deletion.
-func (c *Context) DeleteProgram(program *js.Object) {
+func (c *Context) DeleteProgram(program js.Value) {
 	c.Call("deleteProgram", program)
 }
 
 // Deletes the specified renderbuffer object. If the renderbuffer is
 // currently bound, it will become unbound. If the renderbuffer is
 // attached to the currently bound framebuffer, it is detached.
-func (c *Context) DeleteRenderbuffer(renderbuffer *js.Object) {
+func (c *Context) DeleteRenderbuffer(renderbuffer js.Value) {
 	c.Call("deleteRenderbuffer", renderbuffer)
 }
 
 // Deletes a specific shader object.
-func (c *Context) DeleteShader(shader *js.Object) {
+func (c *Context) DeleteShader(shader js.Value) {
 	c.Call("deleteShader", shader)
 }
 
 // Deletes a specific texture object.
-func (c *Context) DeleteTexture(texture *js.Object) {
+func (c *Context) DeleteTexture(texture js.Value) {
 	c.Call("deleteTexture", texture)
 }
 
@@ -593,7 +593,7 @@ func (c *Context) DepthRange(zNear, zFar float64) {
 }
 
 // Detach a shader object from a program object.
-func (c *Context) DetachShader(program, shader *js.Object) {
+func (c *Context) DetachShader(program, shader js.Value) {
 	c.Call("detachShader", program, shader)
 }
 
@@ -638,12 +638,12 @@ func (c *Context) Flush() {
 
 // Attaches a WebGLRenderbuffer object as a logical buffer to the
 // currently bound WebGLFramebuffer object.
-func (c *Context) FrameBufferRenderBuffer(target, attachment, renderbufferTarget int, renderbuffer *js.Object) {
+func (c *Context) FrameBufferRenderBuffer(target, attachment, renderbufferTarget int, renderbuffer js.Value) {
 	c.Call("framebufferRenderBuffer", target, attachment, renderbufferTarget, renderbuffer)
 }
 
 // Attaches a texture to a WebGLFramebuffer object.
-func (c *Context) FramebufferTexture2D(target, attachment, textarget int, texture *js.Object, level int) {
+func (c *Context) FramebufferTexture2D(target, attachment, textarget int, texture js.Value, level int) {
 	c.Call("framebufferTexture2D", target, attachment, textarget, texture, level)
 }
 
@@ -661,20 +661,20 @@ func (c *Context) GenerateMipmap(target int) {
 
 // Returns an WebGLActiveInfo object containing the size, type, and name
 // of a vertex attribute at a specific index position in a program object.
-func (c *Context) GetActiveAttrib(program *js.Object, index int) *js.Object {
+func (c *Context) GetActiveAttrib(program js.Value, index int) js.Value {
 	return c.Call("getActiveAttrib", program, index)
 }
 
 // Returns an WebGLActiveInfo object containing the size, type, and name
 // of a uniform attribute at a specific index position in a program object.
-func (c *Context) GetActiveUniform(program *js.Object, index int) *js.Object {
+func (c *Context) GetActiveUniform(program js.Value, index int) js.Value {
 	return c.Call("getActiveUniform", program, index)
 }
 
 // Returns a slice of WebGLShaders bound to a WebGLProgram.
-func (c *Context) GetAttachedShaders(program *js.Object) []*js.Object {
+func (c *Context) GetAttachedShaders(program js.Value) []js.Value {
 	objs := c.Call("getAttachedShaders", program)
-	shaders := make([]*js.Object, objs.Length())
+	shaders := make([]js.Value, objs.Length())
 	for i := 0; i < objs.Length(); i++ {
 		shaders[i] = objs.Index(i)
 	}
@@ -682,19 +682,19 @@ func (c *Context) GetAttachedShaders(program *js.Object) []*js.Object {
 }
 
 // Returns an index to the location in a program of a named attribute variable.
-func (c *Context) GetAttribLocation(program *js.Object, name string) int {
+func (c *Context) GetAttribLocation(program js.Value, name string) int {
 	return c.Call("getAttribLocation", program, name).Int()
 }
 
 // TODO: Create type specific variations.
 // Returns the type of a parameter for a given buffer.
-func (c *Context) GetBufferParameter(target, pname int) *js.Object {
+func (c *Context) GetBufferParameter(target, pname int) js.Value {
 	return c.Call("getBufferParameter", target, pname)
 }
 
 // TODO: Create type specific variations.
 // Returns the natural type value for a constant parameter.
-func (c *Context) GetParameter(pname int) *js.Object {
+func (c *Context) GetParameter(pname int) js.Value {
 	return c.Call("getParameter", pname)
 }
 
@@ -705,58 +705,58 @@ func (c *Context) GetError() int {
 
 // TODO: Create type specific variations.
 // Enables a passed extension, otherwise returns null.
-func (c *Context) GetExtension(name string) *js.Object {
+func (c *Context) GetExtension(name string) js.Value {
 	return c.Call("getExtension", name)
 }
 
 // TODO: Create type specific variations.
 // Gets a parameter value for a given target and attachment.
-func (c *Context) GetFramebufferAttachmentParameter(target, attachment, pname int) *js.Object {
+func (c *Context) GetFramebufferAttachmentParameter(target, attachment, pname int) js.Value {
 	return c.Call("getFramebufferAttachmentParameter", target, attachment, pname)
 }
 
 // Returns the value of the program parameter that corresponds to a supplied pname
 // which is interpreted as an int.
-func (c *Context) GetProgramParameteri(program *js.Object, pname int) int {
+func (c *Context) GetProgramParameteri(program js.Value, pname int) int {
 	return c.Call("getProgramParameter", program, pname).Int()
 }
 
 // Returns the value of the program parameter that corresponds to a supplied pname
 // which is interpreted as a bool.
-func (c *Context) GetProgramParameterb(program *js.Object, pname int) bool {
+func (c *Context) GetProgramParameterb(program js.Value, pname int) bool {
 	return c.Call("getProgramParameter", program, pname).Bool()
 }
 
 // Returns information about the last error that occurred during
 // the failed linking or validation of a WebGL program object.
-func (c *Context) GetProgramInfoLog(program *js.Object) string {
+func (c *Context) GetProgramInfoLog(program js.Value) string {
 	return c.Call("getProgramInfoLog", program).String()
 }
 
 // TODO: Create type specific variations.
 // Returns a renderbuffer parameter from the currently bound WebGLRenderbuffer object.
-func (c *Context) GetRenderbufferParameter(target, pname int) *js.Object {
+func (c *Context) GetRenderbufferParameter(target, pname int) js.Value {
 	return c.Call("getRenderbufferParameter", target, pname)
 }
 
 // TODO: Create type specific variations.
 // Returns the value of the parameter associated with pname for a shader object.
-func (c *Context) GetShaderParameter(shader *js.Object, pname int) *js.Object {
+func (c *Context) GetShaderParameter(shader js.Value, pname int) js.Value {
 	return c.Call("getShaderParameter", shader, pname)
 }
 
 // Returns the value of the parameter associated with pname for a shader object.
-func (c *Context) GetShaderParameterb(shader *js.Object, pname int) bool {
+func (c *Context) GetShaderParameterb(shader js.Value, pname int) bool {
 	return c.Call("getShaderParameter", shader, pname).Bool()
 }
 
 // Returns errors which occur when compiling a shader.
-func (c *Context) GetShaderInfoLog(shader *js.Object) string {
+func (c *Context) GetShaderInfoLog(shader js.Value) string {
 	return c.Call("getShaderInfoLog", shader).String()
 }
 
 // Returns source code string associated with a shader object.
-func (c *Context) GetShaderSource(shader *js.Object) string {
+func (c *Context) GetShaderSource(shader js.Value) string {
 	return c.Call("getShaderSource", shader).String()
 }
 
@@ -772,26 +772,26 @@ func (c *Context) GetSupportedExtensions() []string {
 
 // TODO: Create type specific variations.
 // Returns the value for a parameter on an active texture unit.
-func (c *Context) GetTexParameter(target, pname int) *js.Object {
+func (c *Context) GetTexParameter(target, pname int) js.Value {
 	return c.Call("getTexParameter", target, pname)
 }
 
 // TODO: Create type specific variations.
 // Gets the uniform value for a specific location in a program.
-func (c *Context) GetUniform(program, location *js.Object) *js.Object {
+func (c *Context) GetUniform(program, location js.Value) js.Value {
 	return c.Call("getUniform", program, location)
 }
 
 // Returns a WebGLUniformLocation object for the location
 // of a uniform variable within a WebGLProgram object.
-func (c *Context) GetUniformLocation(program *js.Object, name string) *js.Object {
+func (c *Context) GetUniformLocation(program js.Value, name string) js.Value {
 	return c.Call("getUniformLocation", program, name)
 }
 
 // TODO: Create type specific variations.
 // Returns data for a particular characteristic of a vertex
 // attribute at an index in a vertex attribute array.
-func (c *Context) GetVertexAttrib(index, pname int) *js.Object {
+func (c *Context) GetVertexAttrib(index, pname int) js.Value {
 	return c.Call("getVertexAttrib", index, pname)
 }
 
@@ -803,7 +803,7 @@ func (c *Context) GetVertexAttribOffset(index, pname int) int {
 // public function hint(target:GLenum, mode:GLenum) : Void;
 
 // Returns true if buffer is valid, false otherwise.
-func (c *Context) IsBuffer(buffer *js.Object) bool {
+func (c *Context) IsBuffer(buffer js.Value) bool {
 	return c.Call("isBuffer", buffer).Bool()
 }
 
@@ -813,27 +813,27 @@ func (c *Context) IsContextLost() bool {
 }
 
 // Returns true if buffer is valid, false otherwise.
-func (c *Context) IsFramebuffer(framebuffer *js.Object) bool {
+func (c *Context) IsFramebuffer(framebuffer js.Value) bool {
 	return c.Call("isFramebuffer", framebuffer).Bool()
 }
 
 // Returns true if program object is valid, false otherwise.
-func (c *Context) IsProgram(program *js.Object) bool {
+func (c *Context) IsProgram(program js.Value) bool {
 	return c.Call("isProgram", program).Bool()
 }
 
 // Returns true if buffer is valid, false otherwise.
-func (c *Context) IsRenderbuffer(renderbuffer *js.Object) bool {
+func (c *Context) IsRenderbuffer(renderbuffer js.Value) bool {
 	return c.Call("isRenderbuffer", renderbuffer).Bool()
 }
 
 // Returns true if shader is valid, false otherwise.
-func (c *Context) IsShader(shader *js.Object) bool {
+func (c *Context) IsShader(shader js.Value) bool {
 	return c.Call("isShader", shader).Bool()
 }
 
 // Returns true if texture is valid, false otherwise.
-func (c *Context) IsTexture(texture *js.Object) bool {
+func (c *Context) IsTexture(texture js.Value) bool {
 	return c.Call("isTexture", texture).Bool()
 }
 
@@ -849,7 +849,7 @@ func (c *Context) LineWidth(width float64) {
 
 // Links an attached vertex shader and an attached fragment shader
 // to a program so it can be used by the graphics processing unit (GPU).
-func (c *Context) LinkProgram(program *js.Object) {
+func (c *Context) LinkProgram(program js.Value) {
 	c.Call("linkProgram", program)
 }
 
@@ -868,7 +868,7 @@ func (c *Context) PolygonOffset(factor, units float64) {
 // TODO: Figure out if pixels should be a slice.
 // Reads pixel data into an ArrayBufferView object from a
 // rectangular area in the color buffer of the active frame buffer.
-func (c *Context) ReadPixels(x, y, width, height, format, typ int, pixels *js.Object) {
+func (c *Context) ReadPixels(x, y, width, height, format, typ int, pixels js.Value) {
 	c.Call("readPixels", x, y, width, height, format, typ, pixels)
 }
 
@@ -887,7 +887,7 @@ func (c *Context) Scissor(x, y, width, height int) {
 }
 
 // Sets and replaces shader source code in a shader object.
-func (c *Context) ShaderSource(shader *js.Object, source string) {
+func (c *Context) ShaderSource(shader js.Value, source string) {
 	c.Call("shaderSource", shader, source)
 }
 
@@ -899,8 +899,8 @@ func (c *Context) ShaderSource(shader *js.Object, source string) {
 // public function stencilOpSeparate(face:GLenum, fail:GLenum, zfail:GLenum, zpass:GLenum) : Void;
 
 // Loads the supplied pixel data into a texture.
-func (c *Context) TexImage2D(target, level, internalFormat, format, kind int, image *js.Object) {
-	c.Call("texImage2D", target, level, internalFormat, format, kind, image)
+func (c *Context) TexImage2D(target, level, internalFormat, format, kind int, data []byte) {
+	c.Call("texImage2D", target, level, internalFormat, format, kind, js.TypedArrayOf(data))
 }
 
 // Sets texture parameters for the current texture unit.
@@ -909,47 +909,47 @@ func (c *Context) TexParameteri(target int, pname int, param int) {
 }
 
 // Replaces a portion of an existing 2D texture image with all of another image.
-func (c *Context) TexSubImage2D(target, level, xoffset, yoffset, format, typ int, image *js.Object) {
+func (c *Context) TexSubImage2D(target, level, xoffset, yoffset, format, typ int, image js.Value) {
 	c.Call("texSubImage2D", target, level, xoffset, yoffset, format, typ, image)
 }
 
 // Assigns a floating point value to a uniform variable for the current program object.
-func (c *Context) Uniform1f(location *js.Object, x float32) {
+func (c *Context) Uniform1f(location js.Value, x float32) {
 	c.Call("uniform1f", location, x)
 }
 
 // Assigns a integer value to a uniform variable for the current program object.
-func (c *Context) Uniform1i(location *js.Object, x int) {
+func (c *Context) Uniform1i(location js.Value, x int) {
 	c.Call("uniform1i", location, x)
 }
 
 // Assigns 2 floating point values to a uniform variable for the current program object.
-func (c *Context) Uniform2f(location *js.Object, x, y float32) {
+func (c *Context) Uniform2f(location js.Value, x, y float32) {
 	c.Call("uniform2f", location, x, y)
 }
 
 // Assigns 2 integer values to a uniform variable for the current program object.
-func (c *Context) Uniform2i(location *js.Object, x, y int) {
+func (c *Context) Uniform2i(location js.Value, x, y int) {
 	c.Call("uniform2i", location, x, y)
 }
 
 // Assigns 3 floating point values to a uniform variable for the current program object.
-func (c *Context) Uniform3f(location *js.Object, x, y, z float32) {
+func (c *Context) Uniform3f(location js.Value, x, y, z float32) {
 	c.Call("uniform3f", location, x, y, z)
 }
 
 // Assigns 3 integer values to a uniform variable for the current program object.
-func (c *Context) Uniform3i(location *js.Object, x, y, z int) {
+func (c *Context) Uniform3i(location js.Value, x, y, z int) {
 	c.Call("uniform3i", location, x, y, z)
 }
 
 // Assigns 4 floating point values to a uniform variable for the current program object.
-func (c *Context) Uniform4f(location *js.Object, x, y, z, w float32) {
+func (c *Context) Uniform4f(location js.Value, x, y, z, w float32) {
 	c.Call("uniform4f", location, x, y, z, w)
 }
 
 // Assigns 4 integer values to a uniform variable for the current program object.
-func (c *Context) Uniform4i(location *js.Object, x, y, z, w int) {
+func (c *Context) Uniform4i(location js.Value, x, y, z, w int) {
 	c.Call("uniform4i", location, x, y, z, w)
 }
 
@@ -964,29 +964,29 @@ func (c *Context) Uniform4i(location *js.Object, x, y, z, w int) {
 
 // Sets values for a 2x2 floating point vector matrix into a
 // uniform location as a matrix or a matrix array.
-func (c *Context) UniformMatrix2fv(location *js.Object, transpose bool, value []float32) {
+func (c *Context) UniformMatrix2fv(location js.Value, transpose bool, value []float32) {
 	c.Call("uniformMatrix2fv", location, transpose, value)
 }
 
 // Sets values for a 3x3 floating point vector matrix into a
 // uniform location as a matrix or a matrix array.
-func (c *Context) UniformMatrix3fv(location *js.Object, transpose bool, value []float32) {
+func (c *Context) UniformMatrix3fv(location js.Value, transpose bool, value []float32) {
 	c.Call("uniformMatrix3fv", location, transpose, value)
 }
 
 // Sets values for a 4x4 floating point vector matrix into a
 // uniform location as a matrix or a matrix array.
-func (c *Context) UniformMatrix4fv(location *js.Object, transpose bool, value []float32) {
+func (c *Context) UniformMatrix4fv(location js.Value, transpose bool, value []float32) {
 	c.Call("uniformMatrix4fv", location, transpose, value)
 }
 
 // Set the program object to use for rendering.
-func (c *Context) UseProgram(program *js.Object) {
+func (c *Context) UseProgram(program js.Value) {
 	c.Call("useProgram", program)
 }
 
 // Returns whether a given program can run in the current WebGL state.
-func (c *Context) ValidateProgram(program *js.Object) {
+func (c *Context) ValidateProgram(program js.Value) {
 	c.Call("validateProgram", program)
 }
 

--- a/webgl.go
+++ b/webgl.go
@@ -348,15 +348,18 @@ func (c *Context) initGlConstants() {
 
 	for i := 0; i < num; i++ {
 		field := fields.Field(i)
-		// Ignore the embedded js.Value. All other fields are gl constants.
-		if field.Name != "Value" {
-			// Retrieve value from gl context.
-			jsval := ctx.Get(field.Name)
-			if jsval.Type() == js.TypeNumber {
-				val := int64(jsval.Int())
-				// And set it via reflect.
-				reflect.ValueOf(c).Elem().Field(i).SetInt(val)
-			}
+
+		if field.Name == "Value" {
+			// Ignore the embedded js.Value. All other fields are gl constants.
+			continue
+		}
+
+		// Retrieve value from gl context.
+		jsval := ctx.Get(field.Name)
+		if jsval.Type() == js.TypeNumber {
+			val := int64(jsval.Int())
+			// And set it via reflect.
+			reflect.ValueOf(c).Elem().Field(i).SetInt(val)
 		}
 	}
 }
@@ -382,9 +385,9 @@ func NewContext(canvas js.Value, ca *ContextAttributes) (*Context, error) {
 	attrs.Set("preserveDrawingBuffer", ca.PreserveDrawingBuffer)
 
 	gl := canvas.Call("getContext", "webgl", attrs)
-	if gl == js.Null() {
+	if gl == js.Undefined() {
 		gl = canvas.Call("getContext", "experimental-webgl", attrs)
-		if gl == js.Null() {
+		if gl == js.Undefined() {
 			return nil, errors.New("Creating a webgl context has failed.")
 		}
 	}

--- a/webgl.go
+++ b/webgl.go
@@ -355,12 +355,11 @@ func (c *Context) initGlConstants() {
 		}
 
 		// Retrieve value from gl context.
+		// This will panic if the value does not exist.
 		jsval := ctx.Get(field.Name)
-		if jsval.Type() == js.TypeNumber {
-			val := int64(jsval.Int())
-			// And set it via reflect.
-			reflect.ValueOf(c).Elem().Field(i).SetInt(val)
-		}
+		val := int64(jsval.Int())
+		// And set it via reflect.
+		reflect.ValueOf(c).Elem().Field(i).SetInt(val)
 	}
 }
 

--- a/webgl.go
+++ b/webgl.go
@@ -46,12 +46,6 @@ func DefaultAttributes() *ContextAttributes {
 type Context struct {
 	js.Value
 
-	// NOTE undefined constants in webgl, should be removed here?
-	// INFO_LOG_LENGTH
-	// NUM_COMPRESSED_TEXTURE_FORMATS
-	// SHADER_COMPILER
-	// SHADER_SOURCE_LENGTH
-	// STENCIL_INDEX
 	ARRAY_BUFFER                                 int `js:"ARRAY_BUFFER"`
 	ARRAY_BUFFER_BINDING                         int `js:"ARRAY_BUFFER_BINDING"`
 	ATTACHED_SHADERS                             int `js:"ATTACHED_SHADERS"`
@@ -147,7 +141,6 @@ type Context struct {
 	HIGH_INT                                     int `js:"HIGH_INT"`
 	INCR                                         int `js:"INCR"`
 	INCR_WRAP                                    int `js:"INCR_WRAP"`
-	INFO_LOG_LENGTH                              int `js:"INFO_LOG_LENGTH"`
 	INT                                          int `js:"INT"`
 	INT_VEC2                                     int `js:"INT_VEC2"`
 	INT_VEC3                                     int `js:"INT_VEC3"`
@@ -194,7 +187,6 @@ type Context struct {
 	NONE                                         int `js:"NONE"`
 	NOTEQUAL                                     int `js:"NOTEQUAL"`
 	NO_ERROR                                     int `js:"NO_ERROR"`
-	NUM_COMPRESSED_TEXTURE_FORMATS               int `js:"NUM_COMPRESSED_TEXTURE_FORMATS"`
 	ONE                                          int `js:"ONE"`
 	ONE_MINUS_CONSTANT_ALPHA                     int `js:"ONE_MINUS_CONSTANT_ALPHA"`
 	ONE_MINUS_CONSTANT_COLOR                     int `js:"ONE_MINUS_CONSTANT_COLOR"`
@@ -238,8 +230,6 @@ type Context struct {
 	SAMPLE_COVERAGE_VALUE                        int `js:"SAMPLE_COVERAGE_VALUE"`
 	SCISSOR_BOX                                  int `js:"SCISSOR_BOX"`
 	SCISSOR_TEST                                 int `js:"SCISSOR_TEST"`
-	SHADER_COMPILER                              int `js:"SHADER_COMPILER"`
-	SHADER_SOURCE_LENGTH                         int `js:"SHADER_SOURCE_LENGTH"`
 	SHADER_TYPE                                  int `js:"SHADER_TYPE"`
 	SHADING_LANGUAGE_VERSION                     int `js:"SHADING_LANGUAGE_VERSION"`
 	SHORT                                        int `js:"SHORT"`
@@ -260,7 +250,6 @@ type Context struct {
 	STENCIL_CLEAR_VALUE                          int `js:"STENCIL_CLEAR_VALUE"`
 	STENCIL_FAIL                                 int `js:"STENCIL_FAIL"`
 	STENCIL_FUNC                                 int `js:"STENCIL_FUNC"`
-	STENCIL_INDEX                                int `js:"STENCIL_INDEX"`
 	STENCIL_INDEX8                               int `js:"STENCIL_INDEX8"`
 	STENCIL_PASS_DEPTH_FAIL                      int `js:"STENCIL_PASS_DEPTH_FAIL"`
 	STENCIL_PASS_DEPTH_PASS                      int `js:"STENCIL_PASS_DEPTH_PASS"`


### PR DESCRIPTION
Hi, 

first of all I don't expect this to get merged already! 

This PR adds wasm support via `github.com/gopherjs/gopherwasm/js` to this package but js via gopherjs should also still work. I also removed a few gl constants that are undefined in webgl. And last I changed `TexImage2D` to accept a `[]byte` slice as wished in #11 .

Note that the new function `(c *Context) initGlConstants()` is needed because wasm does not support struct tags. It uses reflection because else we would need to list all gl constants again. If you think this would be better that's no problem to change it. I already have the equivalent function generated and ready.
The struct tags are removed because Gopherjs makes trouble if you try to set a value for a field with struct tag (probably a bug). But we don't need them anyways.


Let me know what you think!